### PR TITLE
pushed founder's involvement year when tree created

### DIFF
--- a/backend/routes/tree.js
+++ b/backend/routes/tree.js
@@ -61,6 +61,12 @@ router.post("/add", authenticate, function (req, res) {
         admins: [req.user.username]
     });
 
+    var year = new Date();
+    var yearStr = year.getFullYear();
+
+    var obj = { "user": req.user.username , "yearStarted": yearStr, "yearEnded": yearStr};
+    newTree.memberInvolvement.push(obj);
+
     newTree.save(function (err, tree) {
         if (err) {
             console.log(err);


### PR DESCRIPTION
Previously, only new members who join a tree is dded to the involvementMember array. 

Now, when a tree is created, creator of tree is also added to the involvementMember array